### PR TITLE
MutableMapping.update may cause problems?

### DIFF
--- a/homura/trainers.py
+++ b/homura/trainers.py
@@ -188,7 +188,8 @@ class TrainerBase(Runner, metaclass=ABCMeta):
             results = dict(loss=loss, output=output)
             self._iteration_map.update(**results)
         else:
-            self._iteration_map.update(**results)
+            for k in results:
+                self._iteration_map[k] = results[k]
         self._iteration_map[DATA] = data
         with torch.no_grad():
             self._callbacks.after_iteration(self._iteration_map)


### PR DESCRIPTION
Python version: 3.6.6
pytorch version: 1.1.0

I encountered some problems that losses would not be saved in `Trainer`.
Carefully investigating, I figured out that this issue disappears if we avoid using `MutableMapping.update`, although I haven't got any idea of the actual reasons...