### PR TITLE
Fix tqdm problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ pip install -U git+https://github.com/moskomule/homura
 ```
 faiss (for faster kNN)
 accimage (for faster image pre-processing)
-cupy
+cupy (homura)
+opt_einsum (for accelerated einsum)
 ```
 
 ## test

--- a/homura/liblog.py
+++ b/homura/liblog.py
@@ -171,10 +171,10 @@ def set_tqdm_stdout_stderr():
     # https://github.com/tqdm/tqdm/blob/master/examples/redirect_print.py
     # Some libraries override sys.stdout, which causes OSError: [Errno 9] Bad file descriptor.
     # To avoid this, this if statement is necessary
-    if isinstance(sys.stdout, (io.TextIOWrapper, DummyTqdmFile)):
+    if isinstance(sys.stdout, io.TextIOWrapper):
         sys.stdout, sys.stderr = map(DummyTqdmFile, _original_stds)
-    else:
-        warnings.warn(f"sys.stdout is unexpected type: {type(sys.stdout)}. "
+    elif not isinstance(sys.stdout, DummyTqdmFile):
+        warnings.warn(f"sys.stdout is unexpected type: {type(sys.stdout)}.\n"
                       f"If you use wandb, set WANDB_CONSOLE=off to avoid tqdm-related problems.",
                       UserWarning)
 

--- a/homura/liblog.py
+++ b/homura/liblog.py
@@ -181,7 +181,7 @@ def set_tqdm_stdout_stderr():
 def tqdm(*args, **kwargs):
     # https://github.com/tqdm/tqdm/blob/master/examples/redirect_print.py
     if kwargs.get("file") is None:
-        kwargs["file"] = _get_file_descripter()
+        kwargs["file"] = _original_stds[0]
         # tqdm seems to prioritize dynamic_ncols over ncols
     if kwargs.get("ncols") is None and kwargs.get("dynamic_ncols") is None:
         kwargs["dynamic_ncols"] = True

--- a/homura/liblog.py
+++ b/homura/liblog.py
@@ -171,11 +171,11 @@ def set_tqdm_stdout_stderr():
     # https://github.com/tqdm/tqdm/blob/master/examples/redirect_print.py
     # Some libraries override sys.stdout, which causes OSError: [Errno 9] Bad file descriptor.
     # To avoid this, this if statement is necessary
-    if isinstance(sys.stdout, io.TextIOWrapper):
+    if isinstance(sys.stdout, (io.TextIOWrapper, DummyTqdmFile)):
         sys.stdout, sys.stderr = map(DummyTqdmFile, _original_stds)
     else:
         warnings.warn(f"sys.stdout is unexpected type: {type(sys.stdout)}. "
-                      f"If you use wandb, for example, set WANDB_CONSOLE=off to avoid tqdm-related problems.",
+                      f"If you use wandb, set WANDB_CONSOLE=off to avoid tqdm-related problems.",
                       UserWarning)
 
 

--- a/homura/liblog.py
+++ b/homura/liblog.py
@@ -174,8 +174,9 @@ def set_tqdm_stdout_stderr():
     if isinstance(sys.stdout, io.TextIOWrapper):
         sys.stdout, sys.stderr = map(DummyTqdmFile, _original_stds)
     else:
-        warnings.warn("sys.stdout is not expected type. If you use wandb, for example, set WANDB_CONSOLE=off to avoid "
-                      "tqdm-related problems.", UserWarning)
+        warnings.warn(f"sys.stdout is unexpected type: {type(sys.stdout)}. "
+                      f"If you use wandb, for example, set WANDB_CONSOLE=off to avoid tqdm-related problems.",
+                      UserWarning)
 
 
 def tqdm(*args, **kwargs):

--- a/homura/liblog.py
+++ b/homura/liblog.py
@@ -174,7 +174,7 @@ def _set_tqdm_handler(level: str or int = logging.INFO,
                 self.handleError(record)
 
     _configure_root_logger()
-    th = TQDMHandler()
+    th = TQDMHandler(level)
     if isinstance(level, str):
         level = _LOG_LEVEL[level]
     th.setLevel(level)

--- a/homura/reporters.py
+++ b/homura/reporters.py
@@ -78,6 +78,7 @@ class TQDMReporter(_ReporterBase):
         self.writer.set_postfix(postfix)
 
         if len(postfix) != len(postfix):
+            # todo: what's this?
             for k, v in {key: value
                          for key, (value, _) in self._temporal_memory.items() if
                          not isinstance(value, Number)}.items():

--- a/homura/utils/__init__.py
+++ b/homura/utils/__init__.py
@@ -1,3 +1,4 @@
+from .backends import einsum, torch_to_xp, xp_to_torch
 from .benchmarks import timeit
 from .containers import TensorDataClass, TensorTuple
 from .distributed import (distributed_print, get_global_rank, get_local_rank, get_num_nodes, get_world_size,

--- a/homura/utils/backends.py
+++ b/homura/utils/backends.py
@@ -5,11 +5,15 @@ import numpy as np
 import torch
 from torch.utils.dlpack import from_dlpack, to_dlpack
 
-from .environment import is_cupy_available
+from .environment import is_cupy_available, is_opteinsum_available
 
-IS_CUPY_AVAILABLE = is_cupy_available()
-if IS_CUPY_AVAILABLE:
+has_cupy = is_cupy_available()
+if has_cupy:
     import cupy
+
+has_opt_einsum = is_opteinsum_available()
+if has_opt_einsum:
+    import opt_einsum
 
 
 def torch_to_xp(input: torch.Tensor
@@ -20,7 +24,7 @@ def torch_to_xp(input: torch.Tensor
     if not isinstance(input, torch.Tensor):
         raise RuntimeError(f'torch_to_numpy expects torch.Tensor as input, but got {type(input)}')
 
-    if IS_CUPY_AVAILABLE and input.is_cuda:
+    if has_cupy and input.is_cuda:
         return cupy.fromDlpack(to_dlpack(input))
     else:
         return input.numpy()
@@ -33,7 +37,14 @@ def xp_to_torch(input: np.ndarray
 
     if isinstance(input, np.ndarray):
         return torch.from_numpy(input)
-    elif IS_CUPY_AVAILABLE and isinstance(input, cupy.ndarray):
+    elif has_cupy and isinstance(input, cupy.ndarray):
         return from_dlpack(cupy.ToDlpack(input))
     else:
         raise RuntimeError(f'xp_to_torch expects numpy/cupy.ndarray as input, but got {type(input)}')
+
+
+def einsum(expr: str,
+           *xs):
+    if has_opt_einsum:
+        return opt_einsum.contract(expr, *xs, backend='torch')
+    return torch.einsum(expr, *xs)

--- a/homura/utils/environment.py
+++ b/homura/utils/environment.py
@@ -40,6 +40,10 @@ def is_cupy_available() -> bool:
     return importlib.util.find_spec("cupy") is not None
 
 
+def is_opteinsum_available() -> bool:
+    return importlib.util.find_spec("opt_einsum") is not None
+
+
 # get environment information
 
 def get_git_hash() -> str:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("requirements.txt") as f:
     requirements = f.read().split()
 
 setup(name="homura-core",
-      version="2021.01.0",
+      version="2021.02.0",
       author="moskomule",
       author_email="hataya@nlab-mpg.jp",
       packages=find_packages(exclude=["test", "docs", "examples"]),


### PR DESCRIPTION
Fix #47. When you use wandb, which overrides sys.stdout, set `WANDB_CONSOLE="off"` or initialize it as `wandb.init(settings=wandb.Settings(console="off", mode="offline", _except_exit=False), **kwargs)`.

See also https://github.com/wandb/client/issues/1265.